### PR TITLE
로그인 로직 추가, 홈 API 진행중, 마이페이지 정리 및 화면 추가

### DIFF
--- a/App.js
+++ b/App.js
@@ -25,11 +25,11 @@ import StoryScreen from "./screens/Story/StoryScreen";
 import MyPageMainScreen from "./screens/MyPage/MyPageMainScreen";
 import Toast from "react-native-toast-message";
 import { toastConfig } from "./component/Toast";
-import MyTravelinningScreen from "./screens/MyPage/MyTravelinningScreen";
-import PrivacySettingsScreen from "./screens/MyPage/PrivacySettingsScreen";
-import PrivacySettingsDetail from "./screens/MyPage/PrivacySettingsDetail";
-import MyPostScreen from "./screens/MyPage/MyPostScreen";
-import MyScrapScreen from "./screens/MyPage/MyScrapScreen";
+import MyTravelinningScreen from "./screens/MyPage/MyTravelInning/MyTravelinningScreen";
+import PrivacySettingsScreen from "./screens/MyPage/Privacy/PrivacySettingsScreen";
+import PrivacySettingsDetail from "./screens/MyPage/Privacy/PrivacySettingsDetail";
+import MyPostScreen from "./screens/MyPage/Post/MyPostScreen";
+import MyScrapScreen from "./screens/MyPage/Scrap/MyScrapScreen";
 import TermsInfoScreen from "./screens/MyPage/TermsInfo/TermsInfoScreen";
 import TermsInfoDetail from "./screens/MyPage/TermsInfo/TermsInfoDetail";
 import SettingScreen from "./screens/MyPage/SettingScreen";
@@ -37,6 +37,8 @@ import SplashScreen from "./screens/SplashScreen";
 import FindPasswordScreen from "./screens/Login/FindPasswordScreen";
 import FindEmailScreen from "./screens/Login/FindEmailScreen";
 import SuccessScreen from "./screens/Login/SuccessScreen";
+import EditProfile from "./screens/MyPage/Profile/EditProfile";
+import EditDetail from "./screens/MyPage/Profile/EditDetail";
 
 const Stack = createNativeStackNavigator();
 
@@ -284,6 +286,20 @@ export default function App() {
         <Stack.Screen
           name="Setting"
           component={SettingScreen}
+          options={{
+            headerShown: false,
+          }}
+        />
+        <Stack.Screen
+          name="EditProfile"
+          component={EditProfile}
+          options={{
+            headerShown: false,
+          }}
+        />
+        <Stack.Screen
+          name="EditDetail"
+          component={EditDetail}
           options={{
             headerShown: false,
           }}

--- a/api/home/home.js
+++ b/api/home/home.js
@@ -1,16 +1,24 @@
 import axios from "axios";
 import { API_URL } from "@env";
 import { showToast } from "../../component/Toast";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 export const loadHeader = async (teamId) => {
   try {
-    const { data } = await axios.post(`${API_URL}/api/home/header`, {
-      teamId: teamId,
-    });
-
+    const token = await AsyncStorage.getItem("jwtToken");
+    console.log(`${API_URL}/api/home/header?teamId=${teamId}`);
+    const { data } = await axios.get(
+      `${API_URL}/api/home/header?teamId=${teamId}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    console.log("data: ", data);
     return data;
   } catch (error) {
-    console.log("verify email code error: ", error);
+    console.log("header load error: ", error);
     showToast("정보 로드에 실패했습니다. 다시 접속해주세요.");
     return false;
   }

--- a/api/login/login.js
+++ b/api/login/login.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { API_URL } from "@env";
 import { showToast } from "../../component/Toast";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 export const changePassword = async (email, password) => {
   try {
@@ -18,11 +19,13 @@ export const changePassword = async (email, password) => {
 
 export const login = async (email, password) => {
   try {
-    const response = await axios.post(`${API_URL}/api/members/login`, {
+    const { data } = await axios.post(`${API_URL}/api/members/login`, {
       email: email,
       password: password,
     });
-    return response.data.isSuccess;
+    await AsyncStorage.setItem("jwtToken", data.result.jwt);
+
+    return data.isSuccess;
   } catch (error) {
     console.log("login error: ", error);
     showToast("아이디와 비밀번호를 확인해주세요.");

--- a/app.json
+++ b/app.json
@@ -24,6 +24,10 @@
     "web": {
       "favicon": "./assets/favicon.png"
     },
-    "plugins": ["expo-font", "expo-asset"]
+    "plugins": [
+      "expo-font",
+      "expo-asset",
+      "expo-secure-store"
+    ]
   }
 }

--- a/component/MyPage/MyPageComp.js
+++ b/component/MyPage/MyPageComp.js
@@ -6,7 +6,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import { theme } from "../../colors/color";
+import { SCREEN_HEIGHT, theme } from "../../colors/color";
 import ScrollPicker from "react-native-wheel-scrollview-picker";
 
 export const MyPageModal = ({ visible, onClose, buttonPosition }) => {

--- a/component/MyPage/Profile/ConfirmBtn.js
+++ b/component/MyPage/Profile/ConfirmBtn.js
@@ -1,0 +1,24 @@
+import { Text, TouchableOpacity } from "react-native";
+import { SCREEN_HEIGHT, theme } from "../../../colors/color";
+import { useNavigation } from "@react-navigation/native";
+
+export const ConfirmBtn = ({ text = "완료", confirmFunc }) => {
+  const navigation = useNavigation();
+  const onPress = confirmFunc || (() => navigation.goBack());
+
+  return (
+    <TouchableOpacity onPress={onPress}>
+      <Text
+        style={{
+          alignSelf: "center",
+          fontFamily: "Pretendard-SemiBold",
+          fontSize: 21,
+          color: theme.main_blue,
+          marginBottom: SCREEN_HEIGHT / 8,
+        }}
+      >
+        {text}
+      </Text>
+    </TouchableOpacity>
+  );
+};

--- a/component/MyPage/Profile/EditGender.js
+++ b/component/MyPage/Profile/EditGender.js
@@ -1,0 +1,98 @@
+import {
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { ConfirmBtn } from "./ConfirmBtn";
+import { useState } from "react";
+import { mypage } from "../../../styles/mypage/mypage";
+import { Shadow } from "react-native-shadow-2";
+import { theme } from "../../../colors/color";
+
+const genderMap = {
+  MALE: "남성",
+  FEMALE: "여성",
+};
+
+export default function EditGender() {
+  const [gender, setGender] = useState("");
+
+  return (
+    <>
+      <View style={styles.container}>
+        <Shadow
+          distance={2}
+          startColor="rgba(0, 0, 0, 0.1)"
+          finalColor="rgba(0, 0, 0, 0)"
+          style={{ width: "100%" }}
+        >
+          <View style={mypage.editInput}>
+            <Text style={styles.text}>{genderMap[gender]}</Text>
+          </View>
+        </Shadow>
+        <View style={styles.btnGroup}>
+          <Shadow
+            distance={2}
+            startColor="rgba(0, 0, 0, 0.1)"
+            finalColor="rgba(0, 0, 0, 0)"
+            containerViewStyle={{ flex: 1, width: "100%" }}
+          >
+            <TouchableOpacity
+              onPress={() => setGender("MALE")}
+              style={[styles.button, gender === "MALE" && styles.button_active]}
+            >
+              <Text style={styles.text}>남성</Text>
+            </TouchableOpacity>
+          </Shadow>
+          <Shadow
+            distance={2}
+            startColor="rgba(0, 0, 0, 0.1)"
+            finalColor="rgba(0, 0, 0, 0)"
+            containerViewStyle={{ flex: 1 }}
+          >
+            <TouchableOpacity
+              onPress={() => setGender("FEMALE")}
+              style={[
+                styles.button,
+                gender === "FEMALE" && styles.button_active,
+              ]}
+            >
+              <Text style={styles.text}>여성</Text>
+            </TouchableOpacity>
+          </Shadow>
+        </View>
+      </View>
+      <ConfirmBtn />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    gap: 20,
+    paddingHorizontal: 23,
+    paddingVertical: 30,
+  },
+  btnGroup: {
+    flexDirection: "row",
+    gap: 15,
+  },
+  button: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 17,
+    borderRadius: 9,
+    color: theme.main_black,
+  },
+  button_active: {
+    backgroundColor: "#F4F4F4",
+  },
+  text: {
+    fontFamily: "Pretendard-SemiBold",
+    fontSize: 18,
+    color: theme.main_black,
+  },
+});

--- a/component/MyPage/Profile/EditNickname.js
+++ b/component/MyPage/Profile/EditNickname.js
@@ -1,0 +1,38 @@
+import { StyleSheet, TextInput, View } from "react-native";
+import { ConfirmBtn } from "./ConfirmBtn";
+import { useState } from "react";
+import { mypage } from "../../../styles/mypage/mypage";
+import { Shadow } from "react-native-shadow-2";
+
+export default function EditNickname() {
+  const [nickname, setNickname] = useState("");
+
+  return (
+    <>
+      <View style={styles.container}>
+        <Shadow
+          distance={2}
+          startColor="rgba(0, 0, 0, 0.1)"
+          finalColor="rgba(0, 0, 0, 0)"
+          style={{ width: "100%" }}
+        >
+          <TextInput
+            placeholder={"닉네임 입력"}
+            value={nickname}
+            onChangeText={setNickname}
+            style={mypage.editInput}
+          />
+        </Shadow>
+      </View>
+      <ConfirmBtn />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: 23,
+    paddingVertical: 30,
+  },
+});

--- a/component/MyPage/Profile/EditProfileNavBtn.js
+++ b/component/MyPage/Profile/EditProfileNavBtn.js
@@ -1,0 +1,56 @@
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { Shadow } from "react-native-shadow-2";
+import RightArrow from "../../../assets/icon/mypage/right_arrow_gray.svg";
+import { theme } from "../../../colors/color";
+
+export const EditProfileNavBtn = ({ title, content, navFunc }) => {
+  return (
+    <Shadow
+      distance={2}
+      startColor="rgba(0, 0, 0, 0.1)"
+      finalColor="rgba(0, 0, 0, 0)"
+      style={{ width: "100%" }}
+    >
+      <TouchableOpacity
+        activeOpacity={0.5}
+        onPress={navFunc}
+        style={styles.buttonBox}
+      >
+        <View style={styles.textBox}>
+          <Text style={styles.title}>{title}</Text>
+          <Text style={styles.content}>{content}</Text>
+        </View>
+        <RightArrow />
+      </TouchableOpacity>
+    </Shadow>
+  );
+};
+
+const styles = StyleSheet.create({
+  buttonBox: {
+    flexDirection: "row",
+    width: "100%",
+    alignItems: "center",
+    gap: 25,
+    backgroundColor: "#F4F4F4",
+    borderRadius: 9,
+    paddingHorizontal: 20,
+    paddingVertical: 17,
+  },
+  textBox: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  title: {
+    fontFamily: "Pretendard-Regular",
+    fontSize: 18,
+    color: theme.main_black,
+  },
+  content: {
+    fontFamily: "Pretendard-SemiBold",
+    fontSize: 18,
+    color: theme.main_black,
+  },
+});

--- a/hooks/useDoubleBackExit.js
+++ b/hooks/useDoubleBackExit.js
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from "react";
+import { BackHandler } from "react-native";
+import { showToast } from "../component/Toast";
+
+/**
+ * 안드로이드에서 뒤로가기 버튼을 두 번 눌러야 앱을 종료하는 훅
+ */
+export const useDoubleBackExit = (message = "한 번 더 누르면 종료됩니다") => {
+  const backPressCount = useRef(0);
+
+  useEffect(() => {
+    const backAction = () => {
+      if (backPressCount.current === 0) {
+        backPressCount.current += 1;
+        showToast(message);
+
+        setTimeout(() => {
+          backPressCount.current = 0;
+        }, 2000); // 2초 내에 다시 누르지 않으면 초기화
+
+        return true; // 기본 뒤로가기 막기
+      } else {
+        BackHandler.exitApp(); // 앱 종료
+        return true;
+      }
+    };
+
+    const backHandler = BackHandler.addEventListener(
+      "hardwareBackPress",
+      backAction
+    );
+
+    return () => backHandler.remove();
+  }, [message]);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "travelinning",
       "version": "1.0.0",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "2.1.2",
         "@react-navigation/bottom-tabs": "^7.1.0",
         "@react-navigation/material-top-tabs": "^7.1.0",
         "@react-navigation/native": "^7.0.14",
@@ -18,6 +19,7 @@
         "expo-font": "~13.3.2",
         "expo-image-picker": "~16.1.4",
         "expo-linear-gradient": "~14.1.5",
+        "expo-secure-store": "~14.2.4",
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
         "react-native": "0.79.5",
@@ -2416,6 +2418,18 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.1.2.tgz",
+      "integrity": "sha512-dvlNq4AlGWC+ehtH12p65+17V0Dx7IecOWl6WanF2ja38O1Dcjjvn7jVzkUHJ5oWkQBlyASurTPlTHgKXyYiow==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -5033,6 +5047,15 @@
         "invariant": "^2.2.4"
       }
     },
+    "node_modules/expo-secure-store": {
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-14.2.4.tgz",
+      "integrity": "sha512-ePaz4fnTitJJZjAiybaVYGfLWWyaEtepZC+vs9ZBMhQMfG5HUotIcVsDaSo3FnwpHmgwsLVPY2qFeryI6AtULw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-status-bar": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-2.2.3.tgz",
@@ -5667,6 +5690,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-wsl": {
@@ -6415,6 +6447,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "react-native-svg-transformer": "^1.5.1",
     "react-native-tab-view": "^4.0.5",
     "react-native-toast-message": "^2.2.1",
-    "react-native-wheel-scrollview-picker": "^2.0.9"
+    "react-native-wheel-scrollview-picker": "^2.0.9",
+    "expo-secure-store": "~14.2.4",
+    "@react-native-async-storage/async-storage": "2.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2"

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -9,7 +9,6 @@ import {
   View,
   Animated,
   FlatList,
-  BackHandler,
 } from "react-native";
 import Location from "../assets/icon/location.svg";
 import Notice from "../assets/icon/notification.svg";
@@ -19,46 +18,18 @@ import Filter from "../assets/icon/filter.svg";
 import { theme, SCREEN_WIDTH } from "../colors/color";
 import PlaceCard from "../component/PlaceCard";
 import FilterModal from "../component/FilterModal";
-import { showToast } from "../component/Toast";
-
-// backhandler
-const useDoubleBackExit = () => {
-  const backPressCount = useRef(0);
-
-  useEffect(() => {
-    const backAction = () => {
-      if (backPressCount.current === 0) {
-        backPressCount.current += 1;
-        showToast("한 번 더 누르면 종료됩니다");
-
-        setTimeout(() => {
-          backPressCount.current = 0;
-        }, 2000); // 2초 내에 다시 누르지 않으면 초기화
-
-        return true; // 기본 동작 막기
-      } else {
-        BackHandler.exitApp(); // 앱 종료
-        return true;
-      }
-    };
-
-    const backHandler = BackHandler.addEventListener(
-      "hardwareBackPress",
-      backAction
-    );
-
-    return () => backHandler.remove();
-  }, []);
-};
+import { useDoubleBackExit } from "../hooks/useDoubleBackExit";
+import { loadHeader } from "../api/home/home";
 
 export default function HomeScreen({ navigation }) {
   const [modalVisible, setModalVisible] = useState(false);
+  const [headerData, setHeaderData] = useState(null);
 
-  const scrollY = useRef(new Animated.Value(0)).current; // 스크롤 위치 추적
+  const scrollY = useRef(new Animated.Value(0)).current;
 
   useDoubleBackExit();
 
-  // 이름과 마진 높이와 투명도 조절
+  // animation
   const nameHeight = scrollY.interpolate({
     inputRange: [0, 100], // 스크롤 범위
     outputRange: [40, 0], // 높이가 줄어드는 범위
@@ -74,6 +45,15 @@ export default function HomeScreen({ navigation }) {
     outputRange: [SCREEN_WIDTH / 10, 10], // 높이가 줄어드는 범위
     extrapolate: "clamp",
   });
+
+  useEffect(() => {
+    const handleHeader = async () => {
+      const data = await loadHeader(1);
+      setHeaderData(data);
+    };
+
+    handleHeader();
+  }, []);
 
   return (
     <SafeAreaView style={theme.container}>

--- a/screens/MyPage/MyTravelInning/MyTravelinningScreen.js
+++ b/screens/MyPage/MyTravelInning/MyTravelinningScreen.js
@@ -8,11 +8,11 @@ import {
   TextInput,
   Keyboard,
 } from "react-native";
-import { theme } from "../../colors/color";
-import DropDown from "../../assets/icon/story/dropdown.svg";
+import { theme } from "../../../colors/color";
+import DropDown from "../../../assets/icon/story/dropdown.svg";
 import { useEffect, useRef, useState } from "react";
-import { DateModal } from "../../component/MyPage/MyPageComp";
-import Plus from "../../assets/icon/mypage/plus.svg";
+import { DateModal } from "../../../component/MyPage/MyPageComp";
+import Plus from "../../../assets/icon/mypage/plus.svg";
 import { Shadow } from "react-native-shadow-2";
 import * as ImagePicker from "expo-image-picker";
 
@@ -26,16 +26,16 @@ export default function MyTravelinningScreen({ navigation }) {
   const [memo, setMemo] = useState("");
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
   const imageMap = {
-    KIA: require("../../assets/images/clubs/kia.png"),
-    삼성: require("../../assets/images/clubs/samsung.jpg"),
-    LG: require("../../assets/images/clubs/lg.png"),
-    두산: require("../../assets/images/clubs/doosan.png"),
-    KT: require("../../assets/images/clubs/kt.png"),
-    SSG: require("../../assets/images/clubs/ssg.png"),
-    롯데: require("../../assets/images/clubs/lotte.png"),
-    한화: require("../../assets/images/clubs/hanwha.png"),
-    키움: require("../../assets/images/clubs/kiwoom.png"),
-    NC: require("../../assets/images/clubs/nc.png"),
+    KIA: require("../../../assets/images/clubs/kia.png"),
+    삼성: require("../../../assets/images/clubs/samsung.jpg"),
+    LG: require("../../../assets/images/clubs/lg.png"),
+    두산: require("../../../assets/images/clubs/doosan.png"),
+    KT: require("../../../assets/images/clubs/kt.png"),
+    SSG: require("../../../assets/images/clubs/ssg.png"),
+    롯데: require("../../../assets/images/clubs/lotte.png"),
+    한화: require("../../../assets/images/clubs/hanwha.png"),
+    키움: require("../../../assets/images/clubs/kiwoom.png"),
+    NC: require("../../../assets/images/clubs/nc.png"),
   };
 
   // modal
@@ -190,7 +190,7 @@ export default function MyTravelinningScreen({ navigation }) {
           {/* my */}
           <View style={{ alignItems: "center" }}>
             <Image
-              source={require("../../assets/images/clubs/lotte.png")}
+              source={require("../../../assets/images/clubs/lotte.png")}
               style={styles.clubImage}
             />
             <Text style={styles.myclubText}>나의 구단</Text>

--- a/screens/MyPage/Post/MyPostScreen.js
+++ b/screens/MyPage/Post/MyPostScreen.js
@@ -1,10 +1,10 @@
 import { SafeAreaView, StyleSheet, View, Text, FlatList } from "react-native";
-import { theme } from "../../colors/color";
-import { Header } from "../../component/Header/Header";
+import { theme } from "../../../colors/color";
+import { Header } from "../../../component/Header/Header";
 import { createMaterialTopTabNavigator } from "@react-navigation/material-top-tabs";
 import { useState } from "react";
 import { useRoute } from "@react-navigation/native";
-import { CompCard } from "../../component/MyPage/PrivacySettingComp";
+import { CompCard } from "../../../component/MyPage/PrivacySettingComp";
 
 const Tab = createMaterialTopTabNavigator();
 
@@ -69,7 +69,7 @@ const ScrapScreen = () => {
   같은 ㄴ성별만 원하는데요. ㅇㅇㅇㅇㅇ"
           date="11.01"
           nickname="최강삼성"
-          photo={require("../../assets/images/gowith/logo.png")}
+          photo={require("../../../assets/images/gowith/logo.png")}
           from="gowith"
           isMyPost={true}
         />
@@ -80,7 +80,7 @@ const ScrapScreen = () => {
           category="야구"
           content="한화는 언제쯤 우승해볼 수 있을까? 좋은 선수들은 많이 가지고 있으니니닌까ㅏ깎 "
           date="25.02.28"
-          photo={require("../../assets/images/gowith/logo.png")}
+          photo={require("../../../assets/images/gowith/logo.png")}
           from="story"
           isMyPost={true}
         />

--- a/screens/MyPage/Privacy/PrivacySettingsDetail.js
+++ b/screens/MyPage/Privacy/PrivacySettingsDetail.js
@@ -1,8 +1,8 @@
 import { FlatList, SafeAreaView, StyleSheet, Text, View } from "react-native";
-import { theme } from "../../colors/color";
-import { Header } from "../../component/Header/Header";
+import { theme } from "../../../colors/color";
+import { Header } from "../../../component/Header/Header";
 import React, { useState } from "react";
-import { CompCard } from "../../component/MyPage/PrivacySettingComp";
+import { CompCard } from "../../../component/MyPage/PrivacySettingComp";
 
 export default function PrivacySettingsDetail({ navigation, route }) {
   const { title, subtitle } = route.params;
@@ -18,7 +18,7 @@ export default function PrivacySettingsDetail({ navigation, route }) {
           title="용호만 유람선 터미널"
           content="광안대교나 오륙도를 구경하는 코스로 요트를 타볼 수ㅜ 있느느느느느느느느느ㅡㄴㄴ"
           distance="13"
-          photo={require("../../assets/images/selectphoto/photo1.png")}
+          photo={require("../../../assets/images/selectphoto/photo1.png")}
           from="place"
           isVisibleModal={true}
         />
@@ -31,7 +31,7 @@ export default function PrivacySettingsDetail({ navigation, route }) {
 같은 ㄴ성별만 원하는데요. ㅇㅇㅇㅇㅇ"
           date="11.01"
           nickname="최강삼성"
-          photo={require("../../assets/images/gowith/logo.png")}
+          photo={require("../../../assets/images/gowith/logo.png")}
           from="gowith"
           isVisibleModal={true}
         />
@@ -42,7 +42,7 @@ export default function PrivacySettingsDetail({ navigation, route }) {
           category="야구"
           content="한화는 언제쯤 우승해볼 수 있을까? 좋은 선수들은 많이 가지고 있으니니닌까ㅏ깎 "
           date="25.02.28"
-          photo={require("../../assets/images/gowith/logo.png")}
+          photo={require("../../../assets/images/gowith/logo.png")}
           from="story"
         />
       );

--- a/screens/MyPage/Privacy/PrivacySettingsScreen.js
+++ b/screens/MyPage/Privacy/PrivacySettingsScreen.js
@@ -5,9 +5,9 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import { theme } from "../../colors/color";
-import { Header } from "../../component/Header/Header";
-import Arrow from "../../assets/icon/mypage/right_arrow_gray.svg";
+import { theme } from "../../../colors/color";
+import { Header } from "../../../component/Header/Header";
+import Arrow from "../../../assets/icon/mypage/right_arrow_gray.svg";
 
 export default function PrivacySettingsScreen({ navigation }) {
   const contents = [

--- a/screens/MyPage/Profile/EditDetail.js
+++ b/screens/MyPage/Profile/EditDetail.js
@@ -1,0 +1,29 @@
+import { SafeAreaView } from "react-native";
+import { Header } from "../../../component/Header/Header";
+import { theme } from "../../../colors/color";
+import EditNickname from "../../../component/MyPage/Profile/EditNickname";
+import EditGender from "../../../component/MyPage/Profile/EditGender";
+
+const titleMap = {
+  닉네임: "닉네임 변경",
+  성별: "성별 정보 수정",
+  "소개 메시지": "소개 메시지 수정",
+};
+
+export default function EditDetail({ route }) {
+  const { title } = route.params;
+  console.log(title);
+
+  return (
+    <SafeAreaView style={theme.container}>
+      <Header title={titleMap[title]} />
+      {title === "닉네임" ? (
+        <EditNickname />
+      ) : title === "성별" ? (
+        <EditGender />
+      ) : (
+        <EditIntroduce />
+      )}
+    </SafeAreaView>
+  );
+}

--- a/screens/MyPage/Profile/EditProfile.js
+++ b/screens/MyPage/Profile/EditProfile.js
@@ -1,0 +1,79 @@
+import {
+  Image,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  View,
+  Text,
+  TouchableOpacity,
+} from "react-native";
+import { Header } from "../../../component/Header/Header";
+import { SCREEN_HEIGHT, SCREEN_WIDTH, theme } from "../../../colors/color";
+import { showToast } from "../../../component/Toast";
+import { ConfirmBtn } from "../../../component/MyPage/Profile/ConfirmBtn";
+import { EditProfileNavBtn } from "../../../component/MyPage/Profile/EditProfileNavBtn";
+
+const title = ["닉네임", "성별", "소개 메시지"];
+
+export default function EditProfile({ navigation }) {
+  return (
+    <SafeAreaView style={theme.container}>
+      <Header title="프로필 변경" />
+      <ScrollView contentContainerStyle={styles.container}>
+        <Image
+          source={require("../../../assets/images/gowith/logo.png")}
+          style={styles.profileImage}
+        />
+        <TouchableOpacity>
+          <Text style={styles.profileImgText}>프로필 이미지</Text>
+        </TouchableOpacity>
+        <View style={styles.btnGroup}>
+          {title.map((text, index) => (
+            <EditProfileNavBtn
+              key={index}
+              title={text}
+              content="Jihye"
+              navFunc={() => {
+                navigation.navigate("EditDetail", { title: text });
+              }}
+            />
+          ))}
+        </View>
+      </ScrollView>
+      <ConfirmBtn
+        confirmFunc={() => {
+          showToast("저장 완료!");
+          navigation.goBack();
+        }}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: 23,
+    alignItems: "center",
+  },
+  profileImage: {
+    width: SCREEN_HEIGHT / 8,
+    height: SCREEN_HEIGHT / 8,
+    borderRadius: 100,
+    resizeMode: "cover",
+    marginTop: SCREEN_WIDTH / 10,
+    marginBottom: 20,
+  },
+  profileImgText: {
+    fontFamily: "Pretendard-Medium",
+    fontSize: 14,
+    color: theme.main_blue,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.main_blue,
+    marginBottom: 40,
+  },
+  btnGroup: {
+    width: "100%",
+    gap: 20,
+  },
+});

--- a/screens/MyPage/Scrap/MyScrapScreen.js
+++ b/screens/MyPage/Scrap/MyScrapScreen.js
@@ -1,10 +1,10 @@
 import { SafeAreaView, StyleSheet, View, Text, FlatList } from "react-native";
-import { theme } from "../../colors/color";
-import { Header } from "../../component/Header/Header";
+import { theme } from "../../../colors/color";
+import { Header } from "../../../component/Header/Header";
 import { createMaterialTopTabNavigator } from "@react-navigation/material-top-tabs";
 import { useState } from "react";
 import { useRoute } from "@react-navigation/native";
-import { CompCard } from "../../component/MyPage/PrivacySettingComp";
+import { CompCard } from "../../../component/MyPage/PrivacySettingComp";
 
 const Tab = createMaterialTopTabNavigator();
 
@@ -72,7 +72,7 @@ const ScrapScreen = () => {
           title="용호만 유람선 터미널"
           content="광안대교나 오륙도를 구경하는 코스로 요트를 타볼 수ㅜ 있느느느느느느느느느ㅡㄴㄴ"
           distance="13"
-          photo={require("../../assets/images/selectphoto/photo1.png")}
+          photo={require("../../../assets/images/selectphoto/photo1.png")}
           from="place"
           isScrap={true}
         />
@@ -83,7 +83,7 @@ const ScrapScreen = () => {
           category="야구"
           content="한화는 언제쯤 우승해볼 수 있을까? 좋은 선수들은 많이 가지고 있으니니닌까ㅏ깎 "
           date="25.02.28"
-          photo={require("../../assets/images/gowith/logo.png")}
+          photo={require("../../../assets/images/gowith/logo.png")}
           from="story"
           isScrap={true}
         />
@@ -96,7 +96,7 @@ const ScrapScreen = () => {
   같은 ㄴ성별만 원하는데요. ㅇㅇㅇㅇㅇ"
           date="11.01"
           nickname="최강삼성"
-          photo={require("../../assets/images/gowith/logo.png")}
+          photo={require("../../../assets/images/gowith/logo.png")}
           from="gowith"
           isScrap={true}
         />

--- a/screens/MyPage/SettingScreen.js
+++ b/screens/MyPage/SettingScreen.js
@@ -6,7 +6,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import { SCREEN_HEIGHT, theme } from "../../colors/color";
+import { theme } from "../../colors/color";
 import { Header } from "../../component/Header/Header";
 import { useEffect, useState } from "react";
 
@@ -15,7 +15,13 @@ export default function SettingScreen({ navigation }) {
     require("../../assets/icon/mypage/setting/account.png")
   );
   const contents = [
-    { title: "프로필", icon: profileImg, onPress: () => {} },
+    {
+      title: "프로필",
+      icon: profileImg,
+      onPress: () => {
+        navigation.navigate("EditProfile");
+      },
+    },
     {
       title: "계정",
       icon: require("../../assets/icon/mypage/setting/account.png"),

--- a/screens/SplashScreen.js
+++ b/screens/SplashScreen.js
@@ -1,6 +1,86 @@
-import { Image, ImageBackground, SafeAreaView, StyleSheet } from "react-native";
+import React, { useEffect } from "react";
+import {
+  Image,
+  ImageBackground,
+  SafeAreaView,
+  StyleSheet,
+  ActivityIndicator,
+} from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as SecureStore from "expo-secure-store";
+import { useNavigation } from "@react-navigation/native";
 
 const SplashScreen = () => {
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    const checkAuth = async () => {
+      try {
+        const accessToken = await AsyncStorage.getItem("accessToken");
+        const refreshToken = await SecureStore.getItemAsync("refreshToken");
+
+        if (!accessToken || !refreshToken) {
+          // 토큰 없음 → 로그인 화면으로
+          navigation.reset({
+            index: 0,
+            routes: [{ name: "LoginScreen" }],
+          });
+          return;
+        }
+
+        // 1. access token 검증 요청
+        const res = await fetch("http://your-api.com/auth/validate", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
+        if (res.ok) {
+          // 유효하면 메인 화면으로
+          navigation.reset({
+            index: 0,
+            routes: [{ name: "Main" }],
+          });
+        } else {
+          // access token 만료 → refresh 요청
+          const refreshRes = await fetch("http://your-api.com/auth/refresh", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ refreshToken }),
+          });
+
+          if (refreshRes.ok) {
+            const data = await refreshRes.json();
+            await AsyncStorage.setItem("accessToken", data.accessToken);
+            navigation.reset({
+              index: 0,
+              routes: [{ name: "Main" }],
+            });
+          } else {
+            // refresh 실패 → 로그인 화면으로
+            await AsyncStorage.removeItem("accessToken");
+            await SecureStore.deleteItemAsync("refreshToken");
+            navigation.reset({
+              index: 0,
+              routes: [{ name: "LoginScreen" }],
+            });
+          }
+        }
+      } catch (err) {
+        console.log("Auth check error:", err);
+        navigation.reset({
+          index: 0,
+          routes: [{ name: "LoginScreen" }],
+        });
+      }
+    };
+
+    const timer = setTimeout(() => {
+      checkAuth();
+    }, 1500);
+
+    return () => clearTimeout(timer);
+  }, []);
+
   return (
     <SafeAreaView style={styles.container}>
       <ImageBackground
@@ -10,6 +90,11 @@ const SplashScreen = () => {
         <Image
           source={require("../assets/images/splash/logo.png")}
           style={styles.logo}
+        />
+        <ActivityIndicator
+          size="large"
+          color="#000"
+          style={{ marginTop: 50 }}
         />
       </ImageBackground>
     </SafeAreaView>

--- a/styles/mypage/mypage.js
+++ b/styles/mypage/mypage.js
@@ -1,0 +1,14 @@
+import { theme } from "../../colors/color";
+
+export const mypage = {
+  editInput: {
+    width: "100%",
+    backgroundColor: "#F4F4F4",
+    borderRadius: 9,
+    paddingHorizontal: 20,
+    paddingVertical: 17,
+    fontFamily: "Pretendard-SemiBold",
+    fontSize: 18,
+    color: theme.main_black,
+  },
+};


### PR DESCRIPTION
✨로그인 로직 추가
- jwtToken asyncstoarge에 저장
- Splash 화면에서 로그인 유효성 검사 추가(아직 api가 만들어지지 않아 테스트는 못함)

✨홈 
- useDoubleBackExit 훅 분리
- 홈 헤더 api 연결 (api/home/home.js)

✨마이페이지
- 폴더 구조 정리
- EditProfile, EditDetail 화면 추가
- 그에 따른 component/mypage/profile 폴더안에 컴포넌트들 추가
- styles 폴더 생성 후 mypage 스타일 추가