### PR TITLE
로그인 로직

### DIFF
--- a/App.js
+++ b/App.js
@@ -56,7 +56,7 @@ export default function App() {
   return (
     <NavigationContainer>
       <Stack.Navigator
-        initialRouteName="Main" // 초기 화면 설정
+        initialRouteName="Splash" // 초기 화면 설정
         screenOptions={{
           animation: "fade",
         }}

--- a/api/club/club.js
+++ b/api/club/club.js
@@ -3,7 +3,6 @@ import apiClient from "../../utils/apiClient";
 export const selectClub = async (teamId) => {
   try {
     const { data } = await apiClient.post(`/api/mypage/teams/${teamId}`);
-    console.log("data: ", data);
     return data.isSuccess;
   } catch (error) {
     console.log("select club error: ", error);

--- a/api/login/login.js
+++ b/api/login/login.js
@@ -1,7 +1,6 @@
 import axios from "axios";
 import { API_URL } from "@env";
 import { showToast } from "../../component/Toast";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 
 export const changePassword = async (email, password) => {
   try {
@@ -23,12 +22,35 @@ export const login = async (email, password) => {
       email: email,
       password: password,
     });
-    await AsyncStorage.setItem("jwtToken", data.result.jwt);
-
-    return data.isSuccess;
+    return data.result;
   } catch (error) {
     console.log("login error: ", error);
     showToast("아이디와 비밀번호를 확인해주세요.");
+  }
+};
+
+export const logout = async (token) => {
+  try {
+    const { data } = await axios.post(
+      `${API_URL}/api/members/auth/logout?token=${token}`
+    );
+    return data.isSuccess;
+  } catch (error) {
+    console.log("logout error: ", error);
+    showToast("로그아웃 실패! 잠시 후 다시 시도해주세요.");
+    return false;
+  }
+};
+
+export const refresh = async (refreshToken) => {
+  try {
+    const { data } = await axios.get(
+      `${API_URL}/api/members/auth/refresh?refreshToken=${refreshToken}`
+    );
+    console.log(data);
+    return data;
+  } catch (error) {
+    console.log("refresh error: ", error);
     return false;
   }
 };

--- a/api/mypage/profile/profile.js
+++ b/api/mypage/profile/profile.js
@@ -1,0 +1,11 @@
+import apiClient from "../../../utils/apiClient";
+
+export const loadProfile = async () => {
+  try {
+    const { data } = await apiClient.get(`/api/mypage/my/profile`);
+    return data;
+  } catch (error) {
+    console.log("load profile error: ", error);
+    return false;
+  }
+};

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -68,20 +68,19 @@ export default function HomeScreen({ navigation }) {
   });
 
   useEffect(() => {
-    const handleHeader = async () => {
-      const data = await loadHeader(teamId);
-      setHeaderData(data);
-    };
+    if (isFocused) {
+      const handleHeader = async () => {
+        const id = await AsyncStorage.getItem("teamId");
+        const parseId = id ? parseInt(id, 10) : 1;
+        setTeamId(parseId);
 
-    const loadTeamId = async () => {
-      const data = await AsyncStorage.getItem("teamId");
-      const parsedData = data ? parseInt(data, 10) : 1;
-      setTeamId(parseInt(parsedData, 10));
-    };
+        const data = await loadHeader(parseId);
+        setHeaderData(data);
+      };
 
-    handleHeader();
-    // loadTeamId();
-  }, []);
+      handleHeader();
+    }
+  }, [isFocused]);
 
   useEffect(() => {
     if (isFocused) {

--- a/screens/Login/LoginScreen.js
+++ b/screens/Login/LoginScreen.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   SafeAreaView,
   View,
@@ -9,9 +9,12 @@ import {
   StyleSheet,
   Platform,
   StatusBar,
+  Alert,
 } from "react-native";
 import { SCREEN_HEIGHT, theme } from "../../colors/color";
 import { login } from "../../api/login/login";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as SecureStore from "expo-secure-store";
 
 export default function LoginScreen({ navigation }) {
   const [idInput, setIdInput] = useState("");
@@ -23,8 +26,11 @@ export default function LoginScreen({ navigation }) {
   };
 
   const handleLogin = async () => {
-    const isValid = await login(idInput, passwordInput);
-    if (isValid) {
+    const result = await login(idInput, passwordInput);
+    if (result) {
+      await AsyncStorage.setItem("accessToken", result.jwt);
+      await SecureStore.setItemAsync("refreshToken", result.refreshToken);
+
       navigation.reset({
         index: 0,
         routes: [{ name: "Main" }],

--- a/screens/MyPage/SettingScreen.js
+++ b/screens/MyPage/SettingScreen.js
@@ -9,6 +9,9 @@ import {
 import { theme } from "../../colors/color";
 import { Header } from "../../component/Header/Header";
 import { useEffect, useState } from "react";
+import { logout } from "../../api/login/login";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as SecureStore from "expo-secure-store";
 
 export default function SettingScreen({ navigation }) {
   const [profileImg, setProfileImg] = useState(
@@ -74,6 +77,25 @@ export default function SettingScreen({ navigation }) {
     // 나중에 setProfilImg 세팅하는 코드
   }, []);
 
+  const handleLogout = async () => {
+    try {
+      const accessToken = await AsyncStorage.getItem("accessToken");
+      if (accessToken) {
+        const isSuccess = await logout(accessToken);
+        if (isSuccess) {
+          await AsyncStorage.removeItem("accessToken");
+          await SecureStore.deleteItemAsync("refreshToken");
+          navigation.reset({
+            index: 0,
+            routes: [{ name: "LoginScreen" }],
+          });
+        }
+      }
+    } catch (error) {
+      console.log("logout error: ", error);
+    }
+  };
+
   return (
     <SafeAreaView style={theme.container}>
       <Header title="설정센터" />
@@ -104,7 +126,10 @@ export default function SettingScreen({ navigation }) {
             <Text style={[styles.title, { fontSize: 14 }]}>5.8.36</Text>
           </View>
           {/* logout */}
-          <TouchableOpacity style={[theme.rowContainer, { marginBottom: 20 }]}>
+          <TouchableOpacity
+            onPress={handleLogout}
+            style={[theme.rowContainer, { marginBottom: 20 }]}
+          >
             <Text style={styles.title}>로그아웃</Text>
           </TouchableOpacity>
           {/* delete account */}

--- a/utils/apiClient.js
+++ b/utils/apiClient.js
@@ -1,17 +1,55 @@
 import axios from "axios";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { API_URL } from "@env";
+import { refresh } from "../api/login/login";
 
 const apiClient = axios.create({
   baseURL: API_URL,
 });
 
 apiClient.interceptors.request.use(async (config) => {
-  const token = await AsyncStorage.getItem("jwtToken");
+  const token = await AsyncStorage.getItem("accessToken");
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
   return config;
 });
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      const refreshToken = await SecureStore.getItemAsync("refreshToken");
+      if (refreshToken) {
+        try {
+          const data = await refresh(refreshToken);
+          if (data?.result?.accessToken) {
+            await AsyncStorage.setItem("accessToken", data.result.accessToken);
+            await SecureStore.setItemAsync(
+              "refreshToken",
+              data.result.refreshToken
+            );
+
+            apiClient.defaults.headers.Authorization = `Bearer ${data.result.accessToken}`;
+            originalRequest.headers.Authorization = `Bearer ${data.result.accessToken}`;
+
+            return apiClient(originalRequest);
+          }
+        } catch (refreshError) {
+          console.log("refresh failed:", refreshError);
+        }
+      }
+
+      await AsyncStorage.removeItem("accessToken");
+      await SecureStore.deleteItemAsync("refreshToken");
+    }
+
+    return Promise.reject(error);
+  }
+);
 
 export default apiClient;


### PR DESCRIPTION
- 초기 화면 스플래시로 변경

✨로그인
- login api(login.js)에 login 수정 및 logout, refresh 함수 추가
- mypage api 추가(로그인 유효성 판단용)
- SettingScreen에 로그아웃 추가
- LoginScreen에 로그인 응답 토큰 저장 추가
- SplashScreen에 로그인 유효성 판단 후 화면 이동 로직 추가
- apiClient(커스텀 axios) 수정
  - 토큰 만료 시 refresh
  - 그에 따른 Storage에 토큰들 저장/삭제

✨선호 구단
- 선호 구단 api 테스트 완료
- 선호 구단 변경 후 홈으로 갔을때 정보 반영이 안됨 => 의존 배열에 isFocused 추가
